### PR TITLE
add parse bitmask in return code from smartcl.

### DIFF
--- a/disk.go
+++ b/disk.go
@@ -5,32 +5,94 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"syscall"
 
 	hierr "github.com/reconquest/hierr-go"
 )
 
-func getDiskStats(diskInfo map[string]string) (map[string]string, error) {
-	args := []string{smartctl, "-a"}
-	args = append(args, strings.Split(diskInfo["name"], " ")...)
-	out, err := exec.Command(sudo, args...).CombinedOutput()
-	if err != nil {
-		return nil, hierr.Errorf(
-			out, "can't get stats for %s disk",
-			diskInfo["name"],
+func hasBit(n int64, pos uint) bool {
+	val := n & (1 << pos)
+	return (val > 0)
+}
+
+func errorFromBitMask(diskName string, err error) error {
+
+	var exitCodeSmart = []string{
+		"Bit 0: Command line did not parse",
+		`Bit 1: Device open failed, device did not return an IDENTIFY
+DEVICE structure, or device is in a low-power mode (see '-n' option above)`,
+		`Bit 2: Some SMART command to the disk failed, or there was a
+checksum error in a SMART data structure (see '-b' option above)`,
+		"Bit 3: SMART status check returned DISK FAILING",
+		"Bit 4: We found prefail Attributes <= threshold",
+		`Bit 5: SMART status check returned DISK OK but we found that
+some (usage or prefail) Attributes have been <= threshold
+at some time in the past`,
+		"Bit 6: The device error log contains records of errors",
+		`Bit 7: The device self-test log contains records of errors.
+[ATA only] Failed self-tests outdated by a newer successful extended
+self-test are ignored`,
+	}
+
+	var errorSmart string
+	var waitStatus syscall.WaitStatus
+
+	if exitError, ok := err.(*exec.ExitError); ok {
+		waitStatus = exitError.Sys().(syscall.WaitStatus)
+		bitMaskInt64 := int64(waitStatus.ExitStatus())
+
+		for i := uint(0); i < uint(len(exitCodeSmart)); i++ {
+			if hasBit(bitMaskInt64, i) {
+				errorSmart = fmt.Sprintf("%s%s\n",
+					errorSmart,
+					exitCodeSmart[i],
+				)
+				if i <= 1 {
+					hierr.Fatalf(
+						fmt.Errorf(strings.TrimRight(errorSmart, "\n")),
+						"can't get stats for %s disk",
+						diskName,
+					)
+				}
+			}
+		}
+		return hierr.Errorf(
+			fmt.Errorf(strings.TrimRight(errorSmart, "\n")),
+			"smartctl return not null exit code for %s disk",
+			diskName,
 		)
 	}
 
-	if diskInfo["interface"] == SAS {
-		return getSASStats(diskInfo, string(out))
+	return hierr.Errorf(
+		fmt.Errorf("can't get abnormal exit code"),
+		"smartctl return not null exit code for %s disk",
+		diskName,
+	)
+}
+
+func getDiskStats(diskInfo map[string]string) (map[string]string, error) {
+
+	args := []string{smartctl, "-a"}
+	args = append(args, strings.Split(diskInfo["name"], " ")...)
+	out, err := exec.Command(sudo, args...).CombinedOutput()
+
+	var exitMsg error
+
+	if err != nil {
+		exitMsg = errorFromBitMask(diskInfo["name"], err)
 	}
 
-	return getSATAStats(diskInfo, string(out))
+	if diskInfo["interface"] == SAS {
+		return getSASStats(diskInfo, string(out)), exitMsg
+	}
+	return getSATAStats(diskInfo, string(out)), exitMsg
+
 }
 
 func getSASStats(
 	diskInfo map[string]string,
 	rawStats string,
-) (map[string]string, error) {
+) map[string]string {
 	diskStats := make(map[string]string)
 
 	scanner := bufio.NewScanner(strings.NewReader(rawStats))
@@ -94,13 +156,13 @@ func getSASStats(
 		}
 	}
 
-	return diskStats, nil
+	return diskStats
 }
 
 func getSATAStats(
 	diskInfo map[string]string,
 	rawStats string,
-) (map[string]string, error) {
+) map[string]string {
 	diskStats := make(map[string]string)
 
 	scanner := bufio.NewScanner(strings.NewReader(rawStats))
@@ -158,5 +220,5 @@ func getSATAStats(
 		}
 	}
 
-	return diskStats, nil
+	return diskStats
 }

--- a/main.go
+++ b/main.go
@@ -68,10 +68,15 @@ Options:
 	diskInfo["name"] = args["--disk"].(string)
 	diskInfo["interface"] = args["--interface"].(string)
 
+	var exitMsg = string("OK")
+
 	diskStats, err := getDiskStats(diskInfo)
 	if err != nil {
-		fmt.Println(err.Error())
-		os.Exit(1)
+		exitMsg = err.Error()
+		if diskStats == nil {
+			fmt.Println(exitMsg)
+			os.Exit(1)
+		}
 	}
 
 	var zabbixMetrics []*zsend.Metric
@@ -84,5 +89,5 @@ Options:
 	)
 	sender.Send(packet)
 
-	fmt.Println("OK")
+	fmt.Println(exitMsg)
 }


### PR DESCRIPTION
This pull request extends the processing exit statuses of smartctl.

https://www.smartmontools.org/browser/trunk/smartmontools/smartctl.8.in

The exit statuses of smartctl are defined by a bitmask. If all is well with the disk, the exit status (return value) of smartctl is 0 (all bits turned off). If a problem occurs, or an error, potential error, or fault is detected, then a non-zero status is returned. In this case, the eight different bits in the exit status have the following meanings for ATA disks; some of these values may also be returned for SCSI disks.