### PR TITLE
Skip append duplicate disk in discovery.

### DIFF
--- a/discovery.go
+++ b/discovery.go
@@ -68,6 +68,18 @@ func getDisks(rawOut string) ([]map[string]string, error) {
 				diskName,
 			)
 		}
+		// skip append data if duplicate #SERIAL
+		duplicate := bool(false)
+		for _, disk := range disks {
+			if diskData["{#SERIAL}"] == disk["{#SERIAL}"] {
+				duplicate = true
+				continue
+			}
+		}
+		if duplicate {
+			continue
+		}
+
 		disks = append(disks, diskData)
 	}
 
@@ -96,6 +108,14 @@ func getDiskData(diskName string) (map[string]string, error) {
 	}
 
 	diskInfo := string(rawDiskInfo)
+
+	s := regexp.MustCompile(`Serial (N|n)umber:.+`)
+	serialLines := s.FindAllString(diskInfo, -1)
+	for _, serialLine := range serialLines {
+		diskData["{#SERIAL}"] = strings.TrimSpace(
+			strings.Split(serialLine, ":")[1],
+		)
+	}
 
 	r := regexp.MustCompile(`SMART.+?: +(.+)`)
 	smartStats := r.FindAllString(diskInfo, -1)


### PR DESCRIPTION
smartctl displays a duplicate set of drives if these drives set to JBOD mode via LSI:
```
Enclosure Device ID: 22
Slot Number: 23
Enclosure position: 1
Device Id: 21
...
PD Type: SATA

Raw Size: 111.790 GB [0xdf94bb0 Sectors]
Non Coerced Size: 111.290 GB [0xde94bb0 Sectors]
Coerced Size: 111.281 GB [0xde90000 Sectors]
Sector Size:  512
Logical Sector Size:  512
Physical Sector Size:  512
**Firmware state: JBOD**
Device Firmware Level: 0355
Shield Counter: 0
...
```
```
smartctl --scan-open                                     
/dev/sda -d scsi # /dev/sda, SCSI device # SERIAL_NUMBER_1
...
/dev/bus/0 -d megaraid,8 # /dev/bus/0 [megaraid_disk_08], SCSI device # SERIAL_NUMBER_1
```